### PR TITLE
Set maxlength attribute for plaintext input

### DIFF
--- a/brandis.html
+++ b/brandis.html
@@ -345,13 +345,13 @@ button {
                 </div>
                 <div class="row">
                     <div class="col">
-                        <textarea id="encrypt-public-key" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="encrypt-public-key" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
                     </div>
                     <div class="col">
-                        <textarea id="encrypt-input" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="encrypt-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" maxlength="190"></textarea>
                     </div>
                     <div class="col">
-                        <textarea id="encrypt-output" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="encrypt-output" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
                     </div>
                 </div>
             </div>
@@ -380,13 +380,13 @@ button {
                 </div>
                 <div class="row">
                     <div class="col">
-                        <textarea id="decrypt-private-key" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="decrypt-private-key" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
                     </div>
                     <div class="col">
-                        <textarea id="decrypt-input" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="decrypt-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
                     </div>
                     <div class="col">
-                        <textarea id="decrypt-output" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="decrypt-output" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
                     </div>
                 </div>
             </div>
@@ -425,10 +425,10 @@ button {
                 </div>
                 <div class="row">
                     <div class="col">
-                        <textarea id="public-key" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="public-key" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
                     </div>
                     <div class="col">
-                        <textarea id="private-key" autocompvare="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+                        <textarea id="private-key" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Set the maxlength attribute on plaintext <textarea> input to use built-in browser validation functionality.

Fix typo on autocomplete attributes.